### PR TITLE
Fixes jameelmoses/acf-flexible-content-extended#11

### DIFF
--- a/classes/main.php
+++ b/classes/main.php
@@ -68,12 +68,16 @@ class Main {
 		foreach ( $fields as $field ) {
 			if ( 'flexible_content' === $field['type'] ) {
 				foreach ( $field['layouts'] as $layout_field ) {
+					// Prevent skipping layout fields with identical keys from 
+					// different fields by creating a unique identifier.
+					$field_identifier = $field['key'] . '-' . $layout_field['key'];
+
 					// Don't revisit keys we've recorded already
-					if ( ! empty( $keys[ $layout_field['key'] ] ) ) {
+					if ( ! empty( $keys[ $field_identifier ] ) ) {
 						continue;
 					}
 
-					$keys[ $layout_field['key'] ] = $layout_field['name'];
+					$keys[ $field_identifier ] = $layout_field['name'];
 
 					// Flexible content has a potentially recursive structure. Each layout
 					// has its own sub-fields that could in turn be flexible content.


### PR DESCRIPTION
This pull request fixes issue #11

To quickly test it, you can do the following:

1. Create a new Field Group, call it First, add a Flexible Content field to it with a layout called first-one
2. Verify that your plugin correctly shows the preview for first-one.jpg
3. Duplicate the First Field Group using the inline action, rename it to Second, rename the layout from first-one to second-one
4. If you test it now, you will see that one of the previews (either first-one.jpg or second-one.jpg) will be missing because the layouts have the same internal key and it has been skipped.

My PR solves this by combining the layout key with the flexible content key.
