### PR TITLE
Add filter allowing change to the default file extension expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ add_filter( 'acf-flexible-content-extended.images_path', $path );
 
 **NOTE:** The path should not have a trailing beginning or trailing slash!
 
+You can filter the file extension the plugin searches for. By default the plugin expects `jpg`.
+
+```php
+add_filter( 'acf-flexible-content-extended.images_extension', $extension );
+```
+
+**NOTE:** The extension should not have a leading dot!
+
 Additionally, you could filter all keys and/or images:
 
 ```php

--- a/classes/main.php
+++ b/classes/main.php
@@ -154,11 +154,20 @@ class Main {
 		 */
 		$path = apply_filters( 'acf-flexible-content-extended.images_path', 'lib/admin/images/acf-flexible-content-extended' );
 
+		/**
+		 * Allow to change the file extension expected
+		 *
+		 * @params string $extension : Extension to look for
+		 *
+		 * @return string
+		 */
+		$extension = apply_filters( 'acf-flexible-content-extended.images_extension', 'jpg' );
+
 		// Rework the tpl
 		$layout = str_replace( '_', '-', $layout );
 
-		$image_path = get_stylesheet_directory() . '/' . $path . '/' . $layout . '.jpg';
-		$image_uri = get_stylesheet_directory_uri() . '/' . $path . '/' . $layout . '.jpg';
+		$image_path = get_stylesheet_directory() . '/' . $path . '/' . $layout . '.' . $extension;
+		$image_uri = get_stylesheet_directory_uri() . '/' . $path . '/' . $layout . '.' . $extension;
 
 		// Direct path to custom folder
 		if ( is_file( $image_path ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,12 @@ Also note that you can filter this path, but it **MUST** be in your theme:
 
 **NOTE:** The path should not have a trailing beginning or trailing slash!
 
+You can filter the file extension the plugin searches for. By default the plugin expects `jpg`.
+
+`add_filter( \'acf-flexible-content-extended.images_extension\', $extension );`
+
+**NOTE:** The extension should not have a leading dot!
+
 Additionally, you could filter all keys and/or images:
 
 `add_filter( \'acf-flexible-content-extended.images\', $images );`


### PR DESCRIPTION
This PR adds a hook to change the file format expected by the plugin in its search for images. This can address issue #19 as well as any other format someone would care to use for a site.